### PR TITLE
Separate the setup from the loader

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,6 +18,7 @@ module.exports = function(config) {
 			'node_modules/babel-polyfill/dist/polyfill.js',
 			'node_modules/systemjs/dist/system-polyfills.js',
 			'node_modules/systemjs/dist/system.src.js',
+			'src/system-script-setup.js',
 			{ pattern: 'src/system-script.js', watched: true, included: false, served: true},
 			{ pattern: 'test/fixtures/*', watched: true, included: false, served: true},
 			'test/*.test.js'

--- a/src/system-script-setup.js
+++ b/src/system-script-setup.js
@@ -1,0 +1,21 @@
+window.__systemAmdScript = {};
+
+let scriptNameMap = window.__systemAmdScript.scriptNameMap = {};
+let nameCounter = 0;
+
+window.define = window.canopyDefine = function(name, deps, m) {
+	const outerSystem = __systemAmdScript.SystemJS || SystemJS;
+
+	if (typeof name === "string") {
+		nameCounter++;
+		const newName = `__samds__${name}__${nameCounter}`;
+		scriptNameMap[
+			name.indexOf("!") > -1 ? name.substring(0, name.indexOf("!")) : name
+		] = newName;
+		name = newName;
+	}
+
+	outerSystem.amdDefine(name, deps, m);
+};
+
+window.define.amd = true;

--- a/src/system-script-setup.js
+++ b/src/system-script-setup.js
@@ -1,21 +1,23 @@
-window.__systemAmdScript = {};
+!function() {
+	window.__systemAmdScript = {};
 
-let scriptNameMap = window.__systemAmdScript.scriptNameMap = {};
-let nameCounter = 0;
+	let scriptNameMap = window.__systemAmdScript.scriptNameMap = {};
+	let nameCounter = 0;
 
-window.define = window.canopyDefine = function(name, deps, m) {
-	const outerSystem = __systemAmdScript.SystemJS || SystemJS;
+	window.define = window.canopyDefine = function(name, deps, m) {
+		const outerSystem = __systemAmdScript.SystemJS || SystemJS;
 
-	if (typeof name === "string") {
-		nameCounter++;
-		const newName = `__samds__${name}__${nameCounter}`;
-		scriptNameMap[
-			name.indexOf("!") > -1 ? name.substring(0, name.indexOf("!")) : name
-		] = newName;
-		name = newName;
-	}
+		if (typeof name === "string") {
+			nameCounter++;
+			const newName = `__samds__${name}__${nameCounter}`;
+			scriptNameMap[
+				name.indexOf("!") > -1 ? name.substring(0, name.indexOf("!")) : name
+			] = newName;
+			name = newName;
+		}
 
-	outerSystem.amdDefine(name, deps, m);
-};
+		outerSystem.amdDefine(name, deps, m);
+	};
 
-window.define.amd = true;
+	window.define.amd = true;
+}();

--- a/src/system-script.js
+++ b/src/system-script.js
@@ -1,21 +1,5 @@
-let nameCounter = 0;
-let scriptNameMap = {};
+let scriptNameMap = window.__systemAmdScript.scriptNameMap;
 let outerSystem = SystemJS;
-
-window.define = window.canopyDefine = function(name, deps, m) {
-	if (typeof name === "string") {
-		nameCounter++;
-		const newName = `__samds__${name}__${nameCounter}`;
-		scriptNameMap[
-			name.indexOf("!") > -1 ? name.substring(0, name.indexOf("!")) : name
-		] = newName;
-		name = newName;
-	}
-
-	outerSystem.amdDefine(name, deps, m);
-};
-
-window.define.amd = true;
 
 function normalizeName(name) {
 	return name.indexOf("!") > -1 ? name.substring(0, name.indexOf("!")) : name;
@@ -40,7 +24,7 @@ function getScript(address) {
 }
 
 export function fetch(load) {
-	outerSystem = this;
+	outerSystem = window.__systemAmdScript.SystemJS = this;
 	// Prevent the default XHR request for the resource
 	// and resolve with an empty string. The proper module resolution
 	// happens inside the instantiate hook
@@ -95,13 +79,13 @@ export function instantiate(load) {
 }
 
 const assign = function(target, varArgs) {
-    var to = Object(target);
+    let to = Object(target);
 
-    for (var index = 1; index < arguments.length; index++) {
-      var nextSource = arguments[index];
+    for (let index = 1; index < arguments.length; index++) {
+      let nextSource = arguments[index];
 
-      if (nextSource != null) { // Skip over if undefined or null
-        for (var nextKey in nextSource) {
+      if (nextSource !== null) { // Skip over if undefined or null
+        for (let nextKey in nextSource) {
           // Avoid bugs when hasOwnProperty is shadowed
           if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
             to[nextKey] = nextSource[nextKey];

--- a/test/system-script.test.js
+++ b/test/system-script.test.js
@@ -10,6 +10,9 @@ describe('sofe api', function() {
 		window.define = function () {
 			window.canopyDefine.apply(window, arguments);
 		}
+		Object.keys(window.__systemAmdScript.scriptNameMap).forEach(key => {
+			delete window.__systemAmdScript.scriptNameMap[key];
+		});
 	});
 
 	it('should load modules via script tags with meta config', function(done) {


### PR DESCRIPTION
This allows the user to execute the setup (which defines a global.define)
independent of the loader.