### PR TITLE
WIP: Better error info when modules fail to load

### DIFF
--- a/src/system-script.js
+++ b/src/system-script.js
@@ -71,7 +71,9 @@ export function fetch(load) {
     }
 
     function error(evt) {
-      reject(new Error(`Error loading module from the address: "${load.address}"`));
+      const err = evt && evt.error;
+      const errString = err ? `LoadErr: ${err.message} from ${err.stack}` : 'No error data';
+      reject(new Error(`Error loading module from the address: "${load.address}". ${errString}`));
     }
   });
 }


### PR DESCRIPTION
Currently getting a lot of `Error loading module from the address` errors

The goal is to provide better insight into what is causing them (Unable to reach the CDN, error mounting the code, etc.)

[https://sentry.canopytax.com/canopy/front-end-prod/?query=is%3Aunresolved++Error+loading+module+from+the+address&statsPeriod=14d](url)